### PR TITLE
refactor: replace console logs with NestJS logger

### DIFF
--- a/src/ai/ai.resolver.ts
+++ b/src/ai/ai.resolver.ts
@@ -6,7 +6,7 @@ import { ParsedLabel } from './models/ai-label-response';
 
 @Resolver()
 export class AiResolver {
-    private readonly logger = new Logger(AiService.name);
+    private readonly logger = new Logger(AiResolver.name);
     constructor(private readonly aiService: AiService) {}
 
     @Mutation(() => ParselabelResponse)
@@ -97,17 +97,17 @@ export class AiResolver {
                     }
                 };
             }
-            console.log( {
+            this.logger.debug('Result from AI resolver', {
                 success: true,
                 errors: [],
                 data: {
-                    name: parsedResult.name ,
-                    dosage: parsedResult.dosage ,
-                    quantity: parsedResult.quantity ,
-                    instructions: parsedResult.instructions ,
-                    therapy: parsedResult.therapy 
-                } // Return the JSON string as expected
-            }, 'result from ai resolver');
+                    name: parsedResult.name,
+                    dosage: parsedResult.dosage,
+                    quantity: parsedResult.quantity,
+                    instructions: parsedResult.instructions,
+                    therapy: parsedResult.therapy,
+                },
+            });
             // Return successful response with JSON string data
             return {
                 success: true,
@@ -183,3 +183,4 @@ export class AiResolver {
         }
     }
 }
+

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -29,7 +29,7 @@ export class AiService {
           ],
       });
 
-      console.log(response, 'response from openai');
+      this.logger.debug('Received response from OpenAI API');
 
       // Check if the response structure is as expected
       if (response.choices && response.choices.length > 0) {
@@ -129,3 +129,4 @@ Return ONLY valid JSON. No explanation.
     return errors;
 }
 }
+

--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -1,6 +1,6 @@
 // src/auth/auth.resolver.ts
 import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, Logger } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { CreateUserInput } from '../user/dto/register-user.input';
 import {RefreshResponse} from './dto/refresh-response.dto';
@@ -9,13 +9,14 @@ import {AuthResponse} from './dto/register-user.input'; // Assuming this is the 
 import {VerificationsResponse} from './dto/verificatins-response'
 @Resolver()
 export class AuthResolver {
+  private readonly logger = new Logger(AuthResolver.name);
   constructor(private readonly auth: AuthService) {}
 
   @Mutation(() => AuthResponse, { name: 'registerUser' })
   async registerUser(
     @Args('input') input: CreateUserInput,
   ): Promise<AuthResponse> {
-    console.log('Registering user:', input);
+    this.logger.debug(`Registering user with email: ${input.email}`);
     // First create the user in your DB:
     await this.auth.register(input);
 

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,9 +1,11 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
+  private readonly logger = new Logger(JwtStrategy.name);
+
   constructor() {
     const secret = process.env.JWT_ACCESS_SECRET;
   
@@ -11,15 +13,15 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new Error('JWT_ACCESS_SECRET environment variable is not set');
     }
 
-    console.log('token:', ExtractJwt.fromAuthHeaderAsBearerToken());
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: secret,
     });
+    this.logger.debug('JWT strategy initialized');
   }
 
-  async validate( payload: any) {
-    console.log('JWT payload:', payload);
+  async validate(payload: any) {
+    this.logger.debug(`JWT payload validated for user ${payload?.sub}`);
     return payload;
   }
 }

--- a/src/common/guards/gql-auth-guard.ts
+++ b/src/common/guards/gql-auth-guard.ts
@@ -1,13 +1,15 @@
 // src/common/guards/gql-auth.guard.ts
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class GqlAuthGuard extends AuthGuard('jwt') {
+  private readonly logger = new Logger(GqlAuthGuard.name);
   getRequest(context: ExecutionContext) {
-    console.log('GqlAuthGuard getRequest called');
+    this.logger.debug('GqlAuthGuard getRequest called');
     const ctx = GqlExecutionContext.create(context);
     return ctx.getContext().req; // critical: returns request object for Passport
   }
 }
+

--- a/src/ocr/ocr.resolver.ts
+++ b/src/ocr/ocr.resolver.ts
@@ -1,5 +1,5 @@
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, Logger } from '@nestjs/common';
 import { GqlAuthGuard } from "../common/guards/gql-auth-guard"
 // import { ParseMedicationLabelMultipleInput } from './dto/parse-multiple.input';
 import { OcrService } from './ocr.service';
@@ -8,6 +8,7 @@ import { ParseResponse } from './dto/parse-reponse';
 import { GraphQLUpload, FileUpload } from 'graphql-upload-ts';
 @Resolver()
 export class OcrResolver {
+    private readonly logger = new Logger(OcrResolver.name);
     constructor(private readonly ocrService: OcrService) { }
 
     @Mutation(() => ParseResponse)
@@ -15,7 +16,7 @@ export class OcrResolver {
     async parseMedicationLabelMultiple(
         @Args('input', { type: () => [GraphQLUpload] }) input: FileUpload[],
     ) {
-        console.log(input);
+        this.logger.debug(`Received ${input.length} file(s) for OCR parsing`);
 
         const result = await this.ocrService.parseMultiple(input);
         return {
@@ -25,3 +26,4 @@ export class OcrResolver {
         };
     }
 }
+

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,19 +1,20 @@
 import { Resolver, Mutation, Args, Query, Context } from '@nestjs/graphql';
 import { UserService } from './user.service';
 import { User } from './models/user.model';
-import { UseGuards } from '@nestjs/common';
+import { UseGuards, Logger } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import {GqlAuthGuard } from "../common/guards/gql-auth-guard"
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { UserResponse } from './dto/user-response';
 @Resolver(() => User)
 export class UserResolver {
+  private readonly logger = new Logger(UserResolver.name);
   constructor(private readonly userService: UserService) {}
 
   @Query(() => UserResponse, { name: 'getUser' })
   @UseGuards(GqlAuthGuard)
   async getUser(@CurrentUser() user) {
-    console.log('Current user:', user);
+    this.logger.debug(`Fetching data for user ${user?.sub}`);
     if (!user) {
       throw new Error('User not found');
     }
@@ -21,7 +22,7 @@ export class UserResolver {
     
 
     const userData = await this.userService.findById(user.sub);
-console.log('User data:', userData);
+    this.logger.debug(`Fetched user data for user ${userData?.id}`);
      return {
         success: true,
         errors: [],
@@ -33,3 +34,4 @@ console.log('User data:', userData);
 
  
 }
+

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,14 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserInput } from './dto/register-user.input';
 import { User  } from '@prisma/client';
 
 @Injectable()
 export class UserService {
+  private readonly logger = new Logger(UserService.name);
   constructor(private prisma: PrismaService) {}
 
   async create(data: CreateUserInput): Promise<User> {
-    console.log('Creating user with data:', data);
+    this.logger.debug(`Creating user with email: ${data.email}`);
     let userExists = await this.prisma.user.findUnique({
       where: { email: data.email },
     });
@@ -48,3 +49,4 @@ async getRefreshToken(userId: string): Promise<string | null> {
   }
 
 }
+


### PR DESCRIPTION
## Summary
- replace console.log statements with NestJS Logger across services and resolvers
- avoid logging sensitive data such as tokens or API keys
- add debug-level messages for better observability

## Testing
- `npm test` *(fails: Cannot find module 'src/medication/medication.service' and others)*
- `npm run lint` *(fails: could not find plugin "typescript-eslint")*

------
https://chatgpt.com/codex/tasks/task_e_68916a75930483248d89f25f67c5fc3d