### PR TITLE
refactor: clean up ai resolver imports

### DIFF
--- a/src/ai/ai.resolver.ts
+++ b/src/ai/ai.resolver.ts
@@ -1,8 +1,7 @@
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { Logger } from '@nestjs/common';
 import { AiService } from './ai.service';
 import { ParselabelResponse } from './dto/ai-label-response';
-import { ParsedLabel } from './models/ai-label-response';
 
 @Resolver()
 export class AiResolver {


### PR DESCRIPTION
## Summary
- tidy AI resolver imports by pulling required GraphQL decorators and removing unused code

## Testing
- `npm run build`
- `npm test` (fails: Cannot find module 'src/medication/medication.service' ...)

------
https://chatgpt.com/codex/tasks/task_e_68916a746ab48324b75ac7f3ff4b789f