### PR TITLE
refactor: use system role for AI messages

### DIFF
--- a/src/ai/ai.service.spec.ts
+++ b/src/ai/ai.service.spec.ts
@@ -1,18 +1,39 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { AiService } from './ai.service';
 
 describe('AiService', () => {
   let service: AiService;
+  let mockCreate: jest.Mock;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [AiService],
-    }).compile();
+  beforeEach(() => {
+    process.env.AZURE_OPENAI_ENDPOINT = 'https://example.com';
+    process.env.AZURE_OPENAI_API_KEY = 'key';
+    process.env.AZURE_OPENAI_API_VERSION = '2024-02-15';
+    process.env.AZURE_OPENAI_DEPLOYMENT = 'deployment';
 
-    service = module.get<AiService>(AiService);
+    service = new AiService();
+    mockCreate = jest.fn().mockResolvedValue({
+      choices: [{ message: { content: 'test response' } }],
+    });
+
+    (service as any).openai = {
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    };
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  it('should call OpenAI with system and user messages', async () => {
+    const result = await service.askAi('sys', 'usr');
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: 'gpt-4',
+      messages: [
+        { role: 'system', content: 'sys' },
+        { role: 'user', content: 'usr' },
+      ],
+    });
+    expect(result).toBe('test response');
   });
 });

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -15,11 +15,11 @@ export class AiService {
   async askAi(aiPrompt: string, userPrompt: string): Promise<any> { // Change return type to any, as parsing happens in OcrService
     try {
       this.logger.debug('Calling OpenAI API...');
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-4', // Using gpt-4 as specified
+        const response = await this.openai.chat.completions.create({
+          model: 'gpt-4', // Using gpt-4 as specified
           messages: [
             {
-              role: 'developer',
+              role: 'system',
               content: aiPrompt, // System prompt for AI's role and expected output format
             },
             {
@@ -27,7 +27,7 @@ export class AiService {
               content: userPrompt, // User's specific input for parsing
             },
           ],
-      });
+        });
 
       console.log(response, 'response from openai');
 
@@ -35,6 +35,7 @@ export class AiService {
       if (response.choices && response.choices.length > 0) {
         const content = response.choices[0].message.content;
         this.logger.debug(`Raw content from OpenAI: ${content}`);
+        this.logger.log('OpenAI API call succeeded');
         // With response_format: "json_object", the content should be parseable JSON
         // The JSON.parse will now be handled more safely in OcrService with try/catch
         return content; // Return raw content string to OcrService for parsing


### PR DESCRIPTION
## Summary
- use `system` role for AI prompts instead of `developer`
- add success logging after OpenAI calls
- test message structure for OpenAI requests

## Testing
- `npm test` *(fails: Test Suites: 6 failed, 2 passed, 8 total)*

------
https://chatgpt.com/codex/tasks/task_e_68916a72f1308324a7325849198011c3