### PR TITLE
refactor auth dto

### DIFF
--- a/src/auth/auth.resolver.ts
+++ b/src/auth/auth.resolver.ts
@@ -5,7 +5,7 @@ import { AuthService } from './auth.service';
 import { CreateUserInput } from '../user/dto/register-user.input';
 import {RefreshResponse} from './dto/refresh-response.dto';
 import { GqlAuthGuard } from '../common/guards/gql-auth-guard';
-import {AuthResponse} from './dto/register-user.input'; // Assuming this is the correct import path
+import { AuthResponse } from './dto/auth-response.dto';
 import {VerificationsResponse} from './dto/verificatins-response'
 @Resolver()
 export class AuthResolver {

--- a/src/auth/dto/auth-response.dto.ts
+++ b/src/auth/dto/auth-response.dto.ts
@@ -1,0 +1,6 @@
+import { ObjectType } from '@nestjs/graphql';
+import { ResponseType } from '../../common/dto/response.dto';
+import { LoginResponse } from '../models/login-response.model';
+
+@ObjectType()
+export class AuthResponse extends ResponseType<LoginResponse>(LoginResponse) {}

--- a/src/auth/dto/register-user.input.ts
+++ b/src/auth/dto/register-user.input.ts
@@ -1,16 +1,10 @@
-import { ObjectType, Field, ID } from '@nestjs/graphql';
-import { ResponseType } from '../../common/dto/response.dto';
-import { LoginResponse } from '../models/login-response.model';
-@ObjectType()
+import { InputType, Field } from '@nestjs/graphql';
+
+@InputType()
 export class RegisterUserInput {
-email: string;
-password: string;
-} 
+  @Field()
+  email: string;
 
-
-@ObjectType()
-export class AuthResponse extends ResponseType<LoginResponse>(LoginResponse) {
-    
+  @Field()
+  password: string;
 }
-
-


### PR DESCRIPTION
## Summary
- add dedicated input type for registering users
- move auth response into standalone DTO
- update auth resolver to reference new DTO

## Testing
- `npm test` *(fails: Cannot find module 'src/medication/medication.service' from 'reminder/reminder.service.ts', Nest can't resolve dependencies of the MedicationService, etc.)*
- `npm run lint` *(fails: Could not find plugin 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68916a724b2c8324bcf2ea1a4676b379