### PR TITLE
feat: format register-user input DTO

### DIFF
--- a/src/user/dto/register-user.input.ts
+++ b/src/user/dto/register-user.input.ts
@@ -2,32 +2,30 @@ import { InputType, Field } from '@nestjs/graphql';
 
 @InputType()
 export class CreateUserInput {
-
+  @Field()
+  aud: string;
 
   @Field()
-  aud: string
+  role: string;
 
   @Field()
-  role: string
-
-  @Field()
-  email: string
+  email: string;
 
   @Field({ nullable: true })
-  name?: string 
+  name?: string;
 
   @Field({ nullable: true })
-  phoneNumber?: string
+  phoneNumber?: string;
 
   @Field()
-  password: string
+  password: string;
 
   @Field({ nullable: true })
-  confirmationSentAt?: Date
+  confirmationSentAt?: Date;
 
   @Field()
-  gender: string
+  gender: string;
 
   @Field()
-  dob: Date
+  dob: Date;
 }


### PR DESCRIPTION
## Summary
- ensure GraphQL decorators are imported in `CreateUserInput`
- format the `register-user.input.ts` file and add trailing newline

## Testing
- `npm test` *(fails: Cannot find module 'src/medication/medication.service' and related dependency errors)*
- `npm run lint` *(fails: Could not find plugin 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68916a7089048324ad62f397a25dcbb7