### PR TITLE
Hash refresh tokens and enforce single token per user

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,7 +120,7 @@ model NotificationLog {
 
 model RefreshToken {
   id        String   @id @default(uuid())
-  userId    String
+  userId    String   @unique
   token     String   @unique
   expiresAt DateTime
   createdAt DateTime @default(now())

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -144,9 +144,8 @@ export class AuthService {
 
 
   async refresh(userId: string, token: string) {
-    // verify stored token match
-    const saved = await this.users.getRefreshToken(userId);
-    if (saved !== token) throw new UnauthorizedException("Invalid refresh token");
+    const valid = await this.users.getRefreshToken(userId, token);
+    if (!valid) throw new UnauthorizedException("Invalid refresh token");
 
     const payload = { sub: userId };
     const accessToken = this.jwt.sign(payload);

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserInput } from './dto/register-user.input';
-import { User  } from '@prisma/client';
+import { User } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class UserService {
@@ -26,23 +27,26 @@ export class UserService {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-async getRefreshToken(userId: string): Promise<string | null> {
+  async getRefreshToken(userId: string, token: string): Promise<boolean> {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
       select: { refreshTokens: true },
     });
-    return user?.refreshTokens?.[0]?.token || null;
+    const stored = user?.refreshTokens?.[0]?.token;
+    if (!stored) return false;
+    return bcrypt.compare(token, stored);
   }
 
   async setRefreshToken(userId: string, token: string): Promise<void> {
+    const hashed = await bcrypt.hash(token, 10);
+    const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7);
     await this.prisma.refreshToken.upsert({
-      where: { id: userId }, // Use the correct unique field(s) as per your Prisma schema
-      update: { token },
-      create: { 
-        id: userId, 
-        token, 
-        expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7), // example: 7 days from now
-        user: { connect: { id: userId } }
+      where: { userId },
+      update: { token: hashed, expiresAt, revoked: false },
+      create: {
+        userId,
+        token: hashed,
+        expiresAt,
       },
     });
   }


### PR DESCRIPTION
## Summary
- enforce unique refresh token per user in Prisma schema
- hash refresh tokens and validate using bcrypt
- adjust refresh token retrieval to check hashed value

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: plugin "typescript-eslint" missing)*
- `CI=1 npm test` *(fails: several modules unresolved, 7 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68916a6f79c4832485fc7a0eff77fe08