### PR TITLE
Configure CORS origins from environment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,28 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { graphqlUploadExpress } from 'graphql-upload-ts';
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(graphqlUploadExpress({ maxFileSize: 10_000_000, maxFiles: 5 }));
+
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter((origin) => origin && origin !== '*');
+
   app.enableCors({
-    origin:  '*',
+    origin: allowedOrigins,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-    credentials: true,
-    allowedHeaders: ['Content-Type', 'Authorization', 'apollo-require-preflight', 'x-apollo-operation-name'],
+    credentials: allowedOrigins.length > 0,
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'apollo-require-preflight',
+      'x-apollo-operation-name',
+    ],
   });
   await app.listen(process.env.PORT ?? 8000);
 }
+
 bootstrap();


### PR DESCRIPTION
## Summary
- configure CORS to use explicit origins from `ALLOWED_ORIGINS`
- only enable credentials when an origin list is provided

## Testing
- `npm test` *(fails: Cannot find module 'src/medication/medication.service', missing OpenAI env vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68916a66cb9c8324bef2d3c8f27374cc